### PR TITLE
#251 documentation/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ If you encounter any issues or bugs, please report them via the [GitHub Issues](
 - Expected behavior.
 - Actual behavior.
 - Relevant logs or screenshots.
+
+## CI/CD Status
+
+![Build Status](https://github.com/G-Research/NuGetPackageChecker/actions/workflows/ci.yaml/badge.svg)
+
+For more details, check out the [GitHub Actions](https://github.com/G-Research/NuGetPackageChecker/actions) page.
+
+---
+
+Thank you for using and contributing to NuGetPackageChecker!
+


### PR DESCRIPTION
# Improved README

Added contributing guidelines, which redirects the user to the [CONTRIBUTING.md](https://github.com/G-Research/NuGetPackageChecker/pull/71) (once it is merged), the issue reporting guidelines, and the CI/CD information.

## Issues
- Closes https://github.com/G-Research/oss-portfolio-maturity/issues/251

## Commit explanation

The first commit modifies the README by adding a brief contributing guideline along with a redirect to the CONTRIBUTING.md file

The second commit adds the issue reporting guidelines

The third commit adds the CI/CD badge from the actions page and a link that redirects the user to the actions page for more information 

Done @tabathad!